### PR TITLE
Switch to using tm1-v12-demo.tm1-code.io

### DIFF
--- a/.scripts/delete_model.py
+++ b/.scripts/delete_model.py
@@ -2,8 +2,8 @@ import sys
 from common import *
 
 tm1_database_name = "MiniSData"
-tm1_service_root_url = "http://cwc-tm1-v12-demo.tm1-code.io:4444/tm1/api/v1"
-tm1_service_username = "hubert@tm1-code.io"
+tm1_service_root_url = "http://tm1-v12-demo.tm1-code.io:4444/tm1/api/v1"
+tm1_service_username = "hubert@example.com"
 tm1_service_password = "apple"
 
 # Setup session and authentication

--- a/.scripts/deploy_model.py
+++ b/.scripts/deploy_model.py
@@ -2,8 +2,8 @@ import sys
 from common import *
 
 tm1_database_name = "MiniSData"
-tm1_service_root_url = "http://cwc-tm1-v12-demo.tm1-code.io:4444/tm1/api/v1"
-tm1_service_username = "hubert@tm1-code.io"
+tm1_service_root_url = "http://tm1-v12-demo.tm1-code.io:4444/tm1/api/v1"
+tm1_service_username = "hubert@example.com"
 tm1_service_password = "apple"
 
 # Setup session and authentication

--- a/.scripts/validate_model.py
+++ b/.scripts/validate_model.py
@@ -16,8 +16,8 @@ if len(sys.argv) > 3:
 print(f"Datbase name: {tm1_database_name}")
 print(f"Sourcing from branch: {branch_name}")
 
-tm1_service_root_url = "http://cwc-tm1-v12-demo.tm1-code.io:4444/tm1/api/v1"
-tm1_service_username = "hubert@tm1-code.io"
+tm1_service_root_url = "http://tm1-v12-demo.tm1-code.io:4444/tm1/api/v1"
+tm1_service_username = "hubert@example.com"
 tm1_service_password = "apple"
 
 # Setup session and authentication


### PR DESCRIPTION
This just switches over to the URL for tm1-v12-demo.tm1-code.io and switches back to using security using the more, generic, example.com domain.